### PR TITLE
fix: 修复多分包自定义组件仍然提示的问题

### DIFF
--- a/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
+++ b/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
@@ -51,7 +51,7 @@ function analyzeUsingComponents () {
         return false
       }
       pkgs.add(pkgRoot)
-      if (pkgs.length > 1) { // 被多个分包引用
+      if (pkgs.size > 1) { // 被多个分包引用
         return false
       }
     }


### PR DESCRIPTION
Set 没有 length 方法，当 pkgs 被多个分包引用时这里不会返回，导致控制台依然会产生建议移动到子包的提示